### PR TITLE
fix: tap tests global timeout configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "lint": "eslint lib test",
     "lint:fix": "npm run lint -- --fix",
     "lint:staged": "lint-staged",
-    "test": "tap --coverage-report=html --coverage-report=text --no-browser test",
-    "test:ci": "tap --no-color --coverage-report=json --coverage-report=text test"
+    "test": "tap --coverage-report=html --coverage-report=text --no-browser --timeout=90 test",
+    "test:ci": "tap --no-color --coverage-report=json --coverage-report=text --timeout=90 test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changed the global timeout value for all tap tests, because default was 30s, which is currently more or less the time needed for all the tests to finish (that is why it was randomly failing).

Fixes #70