### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm run lint:staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-promise": "^6.0.0",
         "fastify": "^4.0.0",
-        "husky": "^8.0.0",
+        "husky": "^9.0.11",
         "lint-staged": "^15.0.1",
         "prettier": "^3.0.1",
         "proxyquire": "^2.1.3",
@@ -3571,15 +3571,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true,
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.mjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -11771,9 +11771,9 @@
       "dev": true
     },
     "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true
     },
     "ieee754": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint:staged": "lint-staged",
     "test": "tap --coverage-report=html --coverage-report=text --no-browser --timeout=240 test",
     "test:ci": "tap --no-color --coverage-report=json --coverage-report=text --timeout=240 test",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-promise": "^6.0.0",
     "fastify": "^4.0.0",
-    "husky": "^8.0.0",
+    "husky": "^9.0.11",
     "lint-staged": "^15.0.1",
     "prettier": "^3.0.1",
     "proxyquire": "^2.1.3",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)